### PR TITLE
Fix select page

### DIFF
--- a/resources/public/js/main.js
+++ b/resources/public/js/main.js
@@ -15,9 +15,9 @@
   };
 
   var levelClass = function(level) {
-    if (level == 2) {
+    if (level == "problem") {
       return "level-problem";
-    } else if (level == 1) {
+    } else if (level == "warn") {
       return "level-warn";
     } else {
       return "level-good";


### PR DESCRIPTION
- Cycle pages by the seed number, which in this case is the seconds from the Unix Epoch
- Put problem and warn pages in a higher priority, and cycle those until they are resolved
